### PR TITLE
refactor: call base contract init function

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -78,7 +78,7 @@ contract MachServiceManager is
         address _alertConfirmer
     ) public initializer {
         _initializePauser(_pauserRegistry, _initialPausedStatus);
-        _transferOwnership(_initialOwner);
+        __ServiceManagerBase_init(_initialOwner);
         _setAlertConfirmer(_alertConfirmer);
         allowlistEnabled = true;
         quorumThresholdPercentage = 66;


### PR DESCRIPTION
**Issue:  initialize should call __ServiceManagerBase_init(initialOwner) instead of transferOwnership**

ServiceManagerBase exposes an initialization chain. Use the init function to initialize Base for maximum compatibility.

`src/ServiceManagerBase.sol (Lines 47-49):`
```
function __ServiceManagerBase_init(address initialOwner) internal virtual onlyInitializing {
    _transferOwnership(initialOwner);
}
```
```
function __ServiceManagerBase_init(address initialOwner) internal virtual onlyInitializing {
    _transferOwnership(initialOwner);
}
```