### PR TITLE
fix: remove one unused error

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -28,8 +28,7 @@ import {
     InsufficientThreshold,
     InvalidStartIndex,
     InsufficientThresholdPercentages,
-    InvalidSender,
-    NotAllowed
+    InvalidSender
 } from "../error/Errors.sol";
 import {IMachServiceManager} from "../interfaces/IMachServiceManager.sol";
 

--- a/contracts/src/error/Errors.sol
+++ b/contracts/src/error/Errors.sol
@@ -10,7 +10,6 @@ error InsufficientThreshold();
 error InsufficientThresholdPercentages();
 error AlreadyInAllowlist();
 error NotInAllowlist();
-error NotAllowed();
 
 // Common
 error AlreadyInitialized();


### PR DESCRIPTION
**Issue: Unused Import**

The following Symbols are imported but not used within the Source Unit:

contracts/src/core/MachServiceManager.sol (Lines 32-32):
```
NotAllowed
```