### PR TITLE
fix: add more check on quorum parameter

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -28,7 +28,8 @@ import {
     InsufficientThreshold,
     InvalidStartIndex,
     InsufficientThresholdPercentages,
-    InvalidSender
+    InvalidSender,
+    InvalidQuorumParam
 } from "../error/Errors.sol";
 import {IMachServiceManager} from "../interfaces/IMachServiceManager.sol";
 
@@ -203,11 +204,17 @@ contract MachServiceManager is
         if (tx.origin != msg.sender) {
             revert InvalidSender();
         }
+
         // make sure the stakes against which the Batch is being confirmed are not stale
         if (alertHeader.referenceBlockNumber > block.number) {
             revert InvalidReferenceBlockNum();
         }
         bytes32 hashedHeader = hashAlertHeader(alertHeader);
+
+        // check quorum parameters
+        if (alertHeader.quorumNumbers.length != alertHeader.quorumThresholdPercentages.length) {
+            revert InvalidQuorumParam();
+        }
 
         // check the signature
         (QuorumStakeTotals memory quorumStakeTotals, bytes32 signatoryRecordHash) = checkSignatures(

--- a/contracts/src/error/Errors.sol
+++ b/contracts/src/error/Errors.sol
@@ -8,6 +8,7 @@ error InvalidSender();
 error InvalidReferenceBlockNum();
 error InsufficientThreshold();
 error InsufficientThresholdPercentages();
+error InvalidQuorumParam();
 error AlreadyInAllowlist();
 error NotInAllowlist();
 


### PR DESCRIPTION
**issue: confirmAlert - Missing Array Length Check for quorumNumbers, quorumThresholdPercentage**

confirmAlert is missing a check to enforce that quorumNumbers.length == quorumThresholdPercentage.length. The two arrays are connected as the threshold percent of quorumNumber[x] is at position quorumThresholdPercentage[x]. Note that without this check the two arrays would not be coupled at all. With this check they are at least loosely coupled in length.

contracts/src/core/MachServiceManager.sol (Lines 199-228):
```
function confirmAlert(
    AlertHeader calldata alertHeader,
    NonSignerStakesAndSignature memory nonSignerStakesAndSignature
) external whenNotPaused onlyAlertConfirmer {
    // make sure the information needed to derive the non-signers and batch is in calldata to avoid emitting events
    if (tx.origin != msg.sender) {
        revert InvalidSender();
    }
    // make sure the stakes against which the Batch is being confirmed are not stale
    if (alertHeader.referenceBlockNumber > block.number) {
        revert InvalidReferenceBlockNum();
    }
    bytes32 hashedHeader = hashAlertHeader(alertHeader);

    // check the signature
    (QuorumStakeTotals memory quorumStakeTotals, bytes32 signatoryRecordHash) = checkSignatures(
        hashedHeader,
        alertHeader.quorumNumbers, // use list of uint8s instead of uint256 bitmap to not iterate 256 times
        alertHeader.referenceBlockNumber,
        nonSignerStakesAndSignature
    );

    // check that signatories own at least a threshold percentage of each quourm
    for (uint256 i = 0; i < alertHeader.quorumThresholdPercentages.length; i++) {
        // we don't check that the quorumThresholdPercentages are not >100 because a greater value would trivially fail the check, implying
        // signed stake > total stake
        // signedStakeForQuorum[i] / totalStakeForQuorum[i] * THRESHOLD_DENOMINATOR >= quorumThresholdPercentages[i]
        // => signedStakeForQuorum[i] * THRESHOLD_DENOMINATOR >= totalStakeForQuorum[i] * quorumThresholdPercentages[i]
        uint8 currentQuorumThresholdPercentages = uint8(alertHeader.quorumThresholdPercentages[i]);
        if (currentQuorumThresholdPercentages < quorumThresholdPercentage) {
```