### PR TITLE
fix: reference block num

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -210,7 +210,7 @@ contract MachServiceManager is
         }
 
         // make sure the stakes against which the Batch is being confirmed are not stale
-        if (alertHeader.referenceBlockNumber > block.number) {
+        if (alertHeader.referenceBlockNumber >= block.number) {
             revert InvalidReferenceBlockNum();
         }
         bytes32 hashedHeader = hashAlertHeader(alertHeader);


### PR DESCRIPTION
**Issue: confirmAlert - Inconsistent referenceBlockNumber Staleness Check**

When making sure that the stakes being checked against with are not stale, confirmAlert checks that alertHeader.referenceBlockNumber is not in the future, and at max the current block.number. However, the current block can already be considered in the future because this transaction is part of it. Alerts observed by outsiders and signed upon are very unlikely to be submitted for the current "in the making" block.

This can also be seen in the Documentation: BLSSignatureChecker.md where it is suggested that referenceBlockNumber must be less than block.number. Here's the relevant code part in BLSSignatureChecker:

https://github.com/Layr-Labs/eigenlayer-middleware/blob/dc9d01307a4e98d5d2529bd10ee38682c97e465c/src/BLSSignatureChecker.sol#L115

Since the signature check would fail with referenceBlockNumber < uint32(block.number it is suggested to adjust the check in confirmAlert to be the same as BLSSignatureChecker. Relevant code:

contracts/src/core/MachServiceManager.sol (Lines 207-211):
```
// make sure the stakes against which the Batch is being confirmed are not stale
if (alertHeader.referenceBlockNumber > block.number) {
    revert InvalidReferenceBlockNum();
}
bytes32 hashedHeader = hashAlertHeader(alertHeader);
```