### PR TITLE
feat: setter for confirmer address

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -133,6 +133,13 @@ contract MachServiceManager is
     }
 
     /**
+     * @notice Set confirmer address.
+     */
+    function setConfirmer(address confirmer) external onlyOwner {
+        _setAlertConfirmer(confirmer);
+    }
+
+    /**
      * @notice Remove an Alert.
      * @param messageHash The message hash of the alert
      */


### PR DESCRIPTION
**Issue: The alertConfirmer address cannot be changed**

The alertConfirmer address cannot be changed as _setAlertConfirmer() is declared as internal, and there is no corresponding external function declaration. Thus, if the alertConfirmer account is compromised, there is no way to change it other than performing a contract upgrade