### PR TITLE
fix: check threshold percentage

### DIFF
--- a/contracts/src/error/Errors.sol
+++ b/contracts/src/error/Errors.sol
@@ -9,6 +9,7 @@ error InvalidReferenceBlockNum();
 error InsufficientThreshold();
 error InsufficientThresholdPercentages();
 error InvalidQuorumParam();
+error InvalidQuorumThresholdPercentage();
 error AlreadyInAllowlist();
 error NotInAllowlist();
 error AlreadyAdded();


### PR DESCRIPTION
**Issue: Missing input sanitization in updateQuorumThresholdPercentage**

The function updateQuorumThresholdPercentage() does not have any checks on the input parameter thresholdPercentage. The expected range of an uint8 value is 0 to 255, which means that the quorumThresholdPercentage value could theoretically be set to any value within this range. However, as this value is used as a percentage, acceptable values should be limited to the range 0 to 100.

If no checks are implemented, potential issues could occur. For instance, if the thresholdPercentage is set above 100, it might break the functions that use quorumThresholdPercentage as they might never reach the required quorum.

contracts/src/core/MachServiceManager.sol (Lines 147-150):
```
function updateQuorumThresholdPercentage(uint8 thresholdPercentage) external onlyOwner {
    quorumThresholdPercentage = thresholdPercentage;
    emit QuorumThresholdPercentageChanged(thresholdPercentage);
}
```
Valid ranges are 0-100 as implied by this comment on the individual threshold percentages:

contracts/src/core/MachServiceManager.sol (Lines 222-224):
```
for (uint256 i = 0; i < alertHeader.quorumThresholdPercentages.length; i++) {
    // we don't check that the quorumThresholdPercentages are not >100 because a greater value would trivially fail the check, implying
    // signed stake > total stake
```
It is recommended, to implement a sanity check to verify that the thresholdPercentage is within valid range (0 to 100). One could even further restrict the range for better security. If this condition is not met, the function should revert the operation.

