### PR TITLE
fix: make memory to calldata to reduce gas

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -296,7 +296,7 @@ contract MachServiceManager is
     //////////////////////////////////////////////////////////////////////////////
 
     /// @notice hash the alert header
-    function hashAlertHeader(AlertHeader memory alertHeader) internal pure returns (bytes32) {
+    function hashAlertHeader(AlertHeader calldata alertHeader) internal pure returns (bytes32) {
         return keccak256(abi.encode(convertAlertHeaderToReducedAlertHeader(alertHeader)));
     }
 
@@ -311,7 +311,7 @@ contract MachServiceManager is
      * @notice converts a alert header to a reduced alert header
      * @param alertHeader the alert header to convert
      */
-    function convertAlertHeaderToReducedAlertHeader(AlertHeader memory alertHeader)
+    function convertAlertHeaderToReducedAlertHeader(AlertHeader calldata alertHeader)
         internal
         pure
         returns (ReducedAlertHeader memory)


### PR DESCRIPTION
**Issue: hashAlertHeader() and convertAlertHeaderToReducedAlertHeader should take a calldata argument**

To optimize gas usage, it would be preferable to pass the AlertHeader argument as calldata instead of memory to the functions hashAlertHeader() and convertAlertHeaderToReducedAlertHeader.