### PR TITLE
fix: CEI for registerOperatorToAVS

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -166,12 +166,12 @@ contract MachServiceManager is
         if (allowlistEnabled && !allowlist[operator]) {
             revert NotInAllowlist();
         }
+        // we don't check if this operator has registered or not as AVSDirectory has such checking already
+        _operators.add(operator);
         // Stake requirement for quorum is checked in StakeRegistry.sol
         // https://github.com/Layr-Labs/eigenlayer-middleware/blob/dev/src/RegistryCoordinator.sol#L488
         // https://github.com/Layr-Labs/eigenlayer-middleware/blob/dev/src/StakeRegistry.sol#L84
         _avsDirectory.registerOperatorToAVS(operator, operatorSignature);
-        // we don't check if this operator has registered or not as AVSDirectory has such checking already
-        _operators.add(operator);
         emit OperatorAdded(operator);
     }
 


### PR DESCRIPTION
**Issue: Check-Effect-Interaction violation - registerOperatorToAVS()**

The functionregisterOperatorToAVS() violates the Check-Effect-Interaction pattern. It would be preferable to first add the operator to the _operators set, and then call the external _avsDirectory contract even if it is trusted. There is no security impact in this case as add will silently add the operator to the set anyway. We are mentioning this at this point to foster a secure coding style.