### PR TITLE
fix: check if alert is a resolved one before

### DIFF
--- a/contracts/src/core/MachServiceManagerStorage.sol
+++ b/contracts/src/core/MachServiceManagerStorage.sol
@@ -34,9 +34,12 @@ abstract contract MachServiceManagerStorage {
     /// @notice Minimal quorum threshold percentage
     uint8 public quorumThresholdPercentage;
 
+    /// @notice Resolved message hashes, prevent aggregator from replay any resolved alert
+    EnumerableSet.Bytes32Set internal _resolvedMessageHashes;
+
     // storage gap for upgradeability
     // slither-disable-next-line shadowing-state
-    uint256[46] private __GAP;
+    uint256[45] private __GAP;
 
     constructor(uint256 _rollupChainId) {
         rollupChainId = _rollupChainId;

--- a/contracts/src/error/Errors.sol
+++ b/contracts/src/error/Errors.sol
@@ -13,6 +13,7 @@ error InvalidQuorumThresholdPercentage();
 error AlreadyInAllowlist();
 error NotInAllowlist();
 error AlreadyAdded();
+error ResolvedAlert();
 
 // Common
 error AlreadyInitialized();


### PR DESCRIPTION
**Issue: Alerts Are Removed Completely Instead Of Them Being Invalidated (Audit Trial)**

When removing alerts they are removed from the contract state completely. It would potentially make sense to instead keep that historic information and flag it as invalid only (audit trail), unless there is no need for that and all traces of the alert hash should be removed completely as per the systems design.

For clarification, the client provided the following informaiton:

I think we prefer the second one. Once the alert is handled, should be no more useful. And we can always check event log if we want trace some specific log happens previously

It should be noted, that if alerts are removed from the contract, a corrupted/malfunctioning alertObserver could replay the aggregated signature which would still be valid, which would record the alert in the contract again, and re-emit an AlertConfirmed() event. This could potentially impact off-chain components.

**This PR also fix the following issue:**
The removeAlert() function doesn't check whether messageHash exists before trying to remove it (i.e. via checking the bool return value of Set.remove(). Thus, the function will emit an 'AlertRemoved' event even if the messageHash didn't exist in the first place, or was already deleted.
