### PR TITLE
fix: revert same action if allowlist was already enabled/disabled

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -32,7 +32,9 @@ import {
     InvalidQuorumParam,
     InvalidQuorumThresholdPercentage,
     AlreadyAdded,
-    ResolvedAlert
+    ResolvedAlert,
+    AlreadyEnabled,
+    AlreadyDisabled
 } from "../error/Errors.sol";
 import {IMachServiceManager} from "../interfaces/IMachServiceManager.sol";
 
@@ -122,16 +124,24 @@ contract MachServiceManager is
      * @notice Enable the allowlist.
      */
     function enableAllowlist() external onlyOwner {
-        allowlistEnabled = true;
-        emit AllowlistEnabled();
+        if (allowlistEnabled) {
+            revert AlreadyEnabled();
+        } else {
+            allowlistEnabled = true;
+            emit AllowlistEnabled();
+        }
     }
 
     /**
      * @notice Disable the allowlist.
      */
     function disableAllowlist() external onlyOwner {
-        allowlistEnabled = false;
-        emit AllowlistDisabled();
+        if (!allowlistEnabled) {
+            revert AlreadyDisabled();
+        } else {
+            allowlistEnabled = false;
+            emit AllowlistDisabled();
+        }
     }
 
     /**

--- a/contracts/src/error/Errors.sol
+++ b/contracts/src/error/Errors.sol
@@ -14,6 +14,8 @@ error AlreadyInAllowlist();
 error NotInAllowlist();
 error AlreadyAdded();
 error ResolvedAlert();
+error AlreadyEnabled();
+error AlreadyDisabled();
 
 // Common
 error AlreadyInitialized();


### PR DESCRIPTION
**Issue: removeAlert() succeeds for invalid messageHashes and enableAllowlist(), disableAllowlist() should not emit events if the state is left unchanged**

The removeAlert() function doesn't check whether messageHash exists before trying to remove it (i.e. via checking the bool return value of Set.remove(). Thus, the function will emit an 'AlertRemoved' event even if the messageHash didn't exist in the first place, or was already deleted. 

Note: This issue is resolved in #106 

**This PR fixes the following:**

Similarly, but less of a security problem, the function enableAllowlist() emits events if allowListEnabled is already set to true. Respectively,disableAllowlist() emits events if allowListEnabled is already false. This could be confusing and impact off-chain components as the state of allowlistEnabled will not change, yet the functions will still emit events.

It is therefore, recommended, that function removeAlert() checks the result of the the call to _remove(messageHash) and revert or skip emitting the event if it returns false.