### PR TITLE
fix: include rollup chain ID in ReducedAlertHeader

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -265,17 +265,16 @@ contract MachServiceManager is
      * @inheritdoc IMachServiceManager
      */
     function confirmAlert(
-        uint256 rollupChainId,
         AlertHeader calldata alertHeader,
         NonSignerStakesAndSignature memory nonSignerStakesAndSignature
-    ) external whenNotPaused onlyAlertConfirmer onlyValidRollupChainID(rollupChainId) {
+    ) external whenNotPaused onlyAlertConfirmer onlyValidRollupChainID(alertHeader.rollupChainID) {
         // make sure the information needed to derive the non-signers and batch is in calldata to avoid emitting events
         if (tx.origin != msg.sender) {
             revert InvalidSender();
         }
 
         // check is it is the resolved alert before
-        if (_resolvedMessageHashes[rollupChainId].contains(alertHeader.messageHash)) {
+        if (_resolvedMessageHashes[alertHeader.rollupChainID].contains(alertHeader.messageHash)) {
             revert ResolvedAlert();
         }
 
@@ -319,7 +318,7 @@ contract MachServiceManager is
         }
 
         // store alert
-        bool success = _messageHashes[rollupChainId].add(alertHeader.messageHash);
+        bool success = _messageHashes[alertHeader.rollupChainID].add(alertHeader.messageHash);
         if (!success) {
             revert AlreadyAdded();
         }

--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -413,7 +413,8 @@ contract MachServiceManager is
     {
         return ReducedAlertHeader({
             messageHash: alertHeader.messageHash,
-            referenceBlockNumber: alertHeader.referenceBlockNumber
+            referenceBlockNumber: alertHeader.referenceBlockNumber,
+            rollupChainID: alertHeader.rollupChainID
         });
     }
 

--- a/contracts/src/interfaces/IMachServiceManager.sol
+++ b/contracts/src/interfaces/IMachServiceManager.sol
@@ -157,7 +157,6 @@ interface IMachServiceManager is IServiceManager {
      * - and check whether quorum has been achieved or not.
      */
     function confirmAlert(
-        uint256 rollupChainId,
         AlertHeader calldata alertHeader,
         BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
     ) external;

--- a/contracts/src/interfaces/IMachServiceManager.sol
+++ b/contracts/src/interfaces/IMachServiceManager.sol
@@ -17,11 +17,13 @@ interface IMachServiceManager is IServiceManager {
         bytes quorumThresholdPercentages; // every bytes is an amount less than 100 specifying the percentage of stake
             // the must have signed in the corresponding quorum in `quorumNumbers`
         uint32 referenceBlockNumber;
+        uint256 rollupChainID;
     }
 
     struct ReducedAlertHeader {
         bytes32 messageHash;
         uint32 referenceBlockNumber;
+        uint256 rollupChainID;
     }
 
     /**

--- a/contracts/test/MachServiceManager.t.sol
+++ b/contracts/test/MachServiceManager.t.sol
@@ -29,7 +29,9 @@ contract MachServiceManagerTest is BLSAVSDeployer {
         _deployMockEigenLayerAndAVS();
 
         msgHash = keccak256(
-            abi.encode(IMachServiceManager.ReducedAlertHeader({messageHash: "foo", referenceBlockNumber: 201}))
+            abi.encode(
+                IMachServiceManager.ReducedAlertHeader({messageHash: "foo", referenceBlockNumber: 201, rollupChainID: 1})
+            )
         );
 
         _setAggregatePublicKeysAndSignature();
@@ -264,7 +266,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -298,7 +301,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
         vm.expectRevert(InvalidConfirmer.selector);
         serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
@@ -321,7 +325,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -351,7 +356,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -378,7 +384,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -404,7 +411,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -433,7 +441,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: uint32(block.number)
+            referenceBlockNumber: uint32(block.number),
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -459,7 +468,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -485,7 +495,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -511,7 +522,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);
@@ -537,7 +549,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             messageHash: "foo",
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber
+            referenceBlockNumber: referenceBlockNumber,
+            rollupChainID: 1
         });
 
         vm.startPrank(proxyAdminOwner);

--- a/contracts/test/MachServiceManager.t.sol
+++ b/contracts/test/MachServiceManager.t.sol
@@ -276,7 +276,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
         assertFalse(serviceManager.contains(1, "foo"));
 
         emit AlertConfirmed(msgHash, alertHeader.messageHash);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
 
         assertEq(serviceManager.totalAlerts(1), 1);
         assertTrue(serviceManager.contains(1, "foo"));
@@ -305,7 +305,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             rollupChainID: 1
         });
         vm.expectRevert(InvalidConfirmer.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
     }
 
     function test_ConfirmAlert_RevertIfInvalidSender() public {
@@ -335,7 +335,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
 
         vm.startPrank(address(this));
         vm.expectRevert(InvalidSender.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -361,9 +361,9 @@ contract MachServiceManagerTest is BLSAVSDeployer {
         });
 
         vm.startPrank(proxyAdminOwner);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.expectRevert(AlreadyAdded.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -390,7 +390,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
 
         vm.startPrank(proxyAdminOwner);
         vm.expectRevert(InvalidQuorumParam.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -416,11 +416,11 @@ contract MachServiceManagerTest is BLSAVSDeployer {
         });
 
         vm.startPrank(proxyAdminOwner);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         serviceManager.removeAlert(1, "foo");
 
         vm.expectRevert(ResolvedAlert.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -447,7 +447,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
 
         vm.startPrank(proxyAdminOwner);
         vm.expectRevert(InvalidReferenceBlockNum.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -474,7 +474,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
 
         vm.startPrank(proxyAdminOwner);
         vm.expectRevert(InvalidQuorumThresholdPercentage.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -501,7 +501,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
 
         vm.startPrank(proxyAdminOwner);
         vm.expectRevert(InsufficientThresholdPercentages.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -528,7 +528,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
 
         vm.startPrank(proxyAdminOwner);
         vm.expectRevert(InsufficientThreshold.selector);
-        serviceManager.confirmAlert(1, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 
@@ -550,12 +550,12 @@ contract MachServiceManagerTest is BLSAVSDeployer {
             quorumNumbers: quorumNumbers,
             quorumThresholdPercentages: quorumThresholdPercentages,
             referenceBlockNumber: referenceBlockNumber,
-            rollupChainID: 1
+            rollupChainID: 99
         });
 
         vm.startPrank(proxyAdminOwner);
         vm.expectRevert(InvalidRollupChainID.selector);
-        serviceManager.confirmAlert(99, alertHeader, nonSignerStakesAndSignature);
+        serviceManager.confirmAlert( alertHeader, nonSignerStakesAndSignature);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
This PR includes a rollup chain ID in the ReducedAlertHeader struct.