### PR TITLE
feat: support chain id in confirmAlert

### DIFF
--- a/generic-operator-proxy/cmd/main.go
+++ b/generic-operator-proxy/cmd/main.go
@@ -36,11 +36,17 @@ func main() {
 func operatorProxyMain(ctx *cli.Context) error {
 	log.Println("Initializing Operator Alerter Proxy")
 
-	nodeConfig := proxyUtils.ProxyConfig{}
+	proxyCfg := proxyUtils.ProxyConfig{}
+	if err := config.ReadConfig(ctx, &proxyCfg); err != nil {
+		panic(err)
+	}
+	proxyCfg.WithEnv()
+
+	nodeConfig := genericproxy.MachProxyConfig{}
 	if err := config.ReadConfig(ctx, &nodeConfig); err != nil {
 		panic(err)
 	}
-	nodeConfig.WithEnv()
+	nodeConfig.ProxyConfig = proxyCfg
 
 	mainCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -69,6 +75,7 @@ func operatorProxyMain(ctx *cli.Context) error {
 		nodeConfig.Method,
 		nodeConfig.GenericOperatorAddr,
 		nodeConfig.RpcCfg,
+		nodeConfig.ChainIds,
 	)
 
 	return rpcServer.Start(mainCtx)

--- a/generic-operator-proxy/config.go
+++ b/generic-operator-proxy/config.go
@@ -1,0 +1,9 @@
+package genericproxy
+
+import proxyUtils "github.com/alt-research/avs-generic-aggregator/proxy/utils"
+
+type MachProxyConfig struct {
+	proxyUtils.ProxyConfig
+
+	ChainIds map[string]uint32 `yaml:"chain_ids"`
+}

--- a/generic-operator-proxy/rpc_server.go
+++ b/generic-operator-proxy/rpc_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -28,6 +29,7 @@ type AlertHeaderParam struct {
 	QuorumNumbers              []byte   `abi:"quorumNumbers"`
 	QuorumThresholdPercentages []byte   `abi:"quorumThresholdPercentages"`
 	ReferenceBlockNumber       uint32   `abi:"referenceBlockNumber"`
+	ChainId                    *big.Int `abi:"rollupChainID"`
 }
 
 type CreateSigTaskForByte32Hash struct {
@@ -37,6 +39,7 @@ type CreateSigTaskForByte32Hash struct {
 type ProxyHashRpcServer struct {
 	baseServers    map[string]*proxyUtils.ProxyRpcServerBase
 	avsCfgs        map[string]config.GenericAVSConfig
+	chainIds       map[string]uint32
 	defaultAVSName string
 	logger         logging.Logger
 	// We use this rpc server as the handler for jsonrpc
@@ -54,6 +57,7 @@ func NewAlertProxyRpcServer(
 	method string,
 	genericOperatorAddr string,
 	jsonrpcCfg config.JsonRpcServerConfig,
+	chainIds map[string]uint32,
 ) *ProxyHashRpcServer {
 	bases := make(map[string]*proxyUtils.ProxyRpcServerBase, len(avsCfgs))
 	avsCfgsMap := make(map[string]config.GenericAVSConfig, len(avsCfgs))
@@ -81,6 +85,7 @@ func NewAlertProxyRpcServer(
 		newTaskCreatedChan: newTaskCreatedChan,
 		rpcServer:          rpcServer,
 		avsCfgs:            avsCfgsMap,
+		chainIds:           chainIds,
 	}
 
 	// not need do this because we not need use this server impl
@@ -215,6 +220,12 @@ func (s *ProxyHashRpcServer) createSigTaskH32(ctx context.Context, avsName strin
 	if avsNameToProxy == "" {
 		avsNameToProxy = s.defaultAVSName
 	}
+
+	chainId, ok := s.chainIds[avsNameToProxy]
+	if !ok || chainId == 0 {
+		return proxyUtils.CreateSigTaskResp{}, errors.Errorf("not found chain id for avs name %v", avsNameToProxy)
+	}
+
 	baseServer, ok := s.baseServers[avsNameToProxy]
 	if !ok || baseServer == nil {
 		return proxyUtils.CreateSigTaskResp{}, errors.Errorf("not found avs name %v", avsNameToProxy)
@@ -227,7 +238,10 @@ func (s *ProxyHashRpcServer) createSigTaskH32(ctx context.Context, avsName strin
 			quorumNumbers sdktypes.QuorumNums,
 			quorumThresholdPercentages sdktypes.QuorumThresholdPercentages,
 		) ([]interface{}, [32]byte) {
-			sigHash, err := CalcSighHash(hash, uint32(referenceBlockNumber))
+			chainid := int64(chainId)
+			chainIdBig := big.NewInt(int64(chainid))
+
+			sigHash, err := CalcSighHash(hash, uint32(referenceBlockNumber), chainIdBig)
 			if err != nil {
 				panic(err)
 			}
@@ -238,6 +252,7 @@ func (s *ProxyHashRpcServer) createSigTaskH32(ctx context.Context, avsName strin
 					QuorumNumbers:              quorumNumbers.UnderlyingType(),
 					QuorumThresholdPercentages: quorumThresholdPercentages.UnderlyingType(),
 					ReferenceBlockNumber:       uint32(referenceBlockNumber),
+					ChainId:                    chainIdBig,
 				}}, sigHash
 		})
 	if err != nil {
@@ -257,6 +272,7 @@ var (
 	sighHashAbiParams, _ = abi.NewType("tuple", "Hash32SighHashParam", []abi.ArgumentMarshaling{
 		{Name: "messageHash", Type: "bytes32"},
 		{Name: "referenceBlockNumber", Type: "uint32"},
+		{Name: "rollupChainID", Type: "uint256"},
 	})
 
 	sighHashAbiArgs = abi.Arguments{
@@ -264,13 +280,15 @@ var (
 	}
 )
 
-func CalcSighHash(messageHash [32]byte, referenceBlockNumber uint32) ([32]byte, error) {
+func CalcSighHash(messageHash [32]byte, referenceBlockNumber uint32, chainId *big.Int) ([32]byte, error) {
 	record := struct {
 		MessageHash          [32]byte `abi:"messageHash"`
 		ReferenceBlockNumber uint32   `abi:"referenceBlockNumber"`
+		ChainId              *big.Int `abi:"rollupChainID"`
 	}{
 		MessageHash:          messageHash,
 		ReferenceBlockNumber: referenceBlockNumber,
+		ChainId:              chainId,
 	}
 
 	packed, err := sighHashAbiArgs.Pack(&record)


### PR DESCRIPTION
The proxy will config the chain id for each avs:

```yaml
production: false
eth_rpc_url: http://10.1.1.11:8545

method: "confirmAlert"

generic_operator_addr: http://127.0.0.1:8091

rpc_cfg:
  rpc_addr: 0.0.0.0:8092
  rpc_vhosts: ["*", "localhost"]
  rpc_cors: ["*", "localhost"]

chain_ids:
  altLayer_mach_avs: 11155420
  xterio_mach_avs: 1637450

```

This config will commit to new avs contact.
