### PR TITLE
fix: storage layout for upgrade

### DIFF
--- a/contracts/src/core/MachServiceManagerStorage.sol
+++ b/contracts/src/core/MachServiceManagerStorage.sol
@@ -14,18 +14,22 @@ abstract contract MachServiceManagerStorage {
     // CONSTANTS
     uint256 public constant THRESHOLD_DENOMINATOR = 100;
 
-    // Slot 0
-    mapping(uint256 => EnumerableSet.Bytes32Set) internal _messageHashes;
+    // slot 0
+    /// @notice Allowed rollup chain IDs
+    mapping(uint256 => bool) public rollupChainIDs;
 
     // Slot 1
+    mapping(uint256 => EnumerableSet.Bytes32Set) internal _messageHashes;
+
+    // Slot 2, 3
     /// @notice Ethereum addresses of currently register operators
     EnumerableSet.AddressSet internal _operators;
 
-    // Slot 2
+    // Slot 4
     /// @notice Set of operators that are allowed to register
     mapping(address => bool) public allowlist;
 
-    // Slot 3
+    // Slot 5
     /// @notice address that is permissioned to confirm alerts
     address public alertConfirmer;
 
@@ -35,21 +39,13 @@ abstract contract MachServiceManagerStorage {
     /// @notice Minimal quorum threshold percentage
     uint8 public quorumThresholdPercentage;
 
-    // slot 4
+    // slot 6
     /// @notice Resolved message hashes, prevent aggregator from replay any resolved alert
     mapping(uint256 => EnumerableSet.Bytes32Set) internal _resolvedMessageHashes;
 
-    // slot 5
+    // slot 7
     /// @notice Role for whitelisting operators
     address public whitelister;
-
-    // slot 6
-    /// @notice Rollup chain id
-    uint256 private __DEPRECATED_SLOT6; // rollupChainId
-
-    // slot 7
-    /// @notice Allowed rollup chain IDs
-    mapping(uint256 => bool) public rollupChainIDs;
 
     // storage gap for upgradeability
     // slither-disable-next-line shadowing-state


### PR DESCRIPTION
This PR prepares contract upgrade for this implementation https://etherscan.io/address/0x5cdfb2e7a3b1ade05a0e47c5ab1882ca54eb4168#code by correcting the slot counting.
(proxy: https://etherscan.io/address/0x71a77037870169d47aad6c2C9360861A4C0df2bF#code)
 
 ```solidity
   // CONSTANTS
    uint256 public constant THRESHOLD_DENOMINATOR = 100;

    /// @notice Rollup chain id, it is different from block.chainid
    uint256 public immutable rollupChainId;

// SLOT 0, 1
    EnumerableSet.Bytes32Set internal _messageHashes;


// SLOT 2, 3
    /// @notice Ethereum addresses of currently register operators
    EnumerableSet.AddressSet internal _operators;


// SLOT 4
    /// @notice Set of operators that are allowed to register
    mapping(address => bool) public allowlist;


// SLOT 5
    /// @notice address that is permissioned to confirm alerts
    address public alertConfirmer;


// SLOT 5
    /// @notice Whether or not the allowlist is enabled
    bool public allowlistEnabled;


// SLOT 5
    /// @notice Minimal quorum threshold percentage
    uint8 public quorumThresholdPercentage;


// SLOT 6, 7
    /// @notice Resolved message hashes, prevent aggregator from replay any resolved alert
    EnumerableSet.Bytes32Set internal _resolvedMessageHashes;

// SLOT 8
    /// @notice Role for whitelisting operators
    address public whitelister;

    // storage gap for upgradeability
    // slither-disable-next-line shadowing-state
    uint256[44] private __GAP;
 
 ```
 
 
Note that `Bytes32Set` takes 2 storage slots. 
```solidity
library EnumerableSet {
    // To implement this library for multiple types with as little code
    // repetition as possible, we write it in terms of a generic Set type with
    // bytes32 values.
    // The Set implementation uses private functions, and user-facing
    // implementations (such as AddressSet) are just wrappers around the
    // underlying Set.
    // This means that we can only create new EnumerableSets for types that fit
    // in bytes32.

    struct Set {
        // Storage of set values
        bytes32[] _values;
        // Position of the value in the `values` array, plus 1 because index 0
        // means a value is not in the set.
        mapping(bytes32 => uint256) _indexes;
    }
    ...
 
 ```

In the new implementation we use     
 `mapping(uint256 => EnumerableSet.Bytes32Set)`
 instead of 
 `EnumerableSet.Bytes32Set` for `_messageHashes`.
 
` _messageHashes` is untouched, meaning no state change have been made yet.
  
 Therefore, we can put `mapping(uint256 => bool) rollupChainIDs` to fill the gap, avoiding storage collision. 