### PR TITLE
feat: Proxy support health check by send work proof to generic opeartor

### DIFF
--- a/core/message/info.go
+++ b/core/message/info.go
@@ -6,3 +6,9 @@ type BlockWorkProof struct {
 	BlockHash   hexutil.Bytes `json:"block_hash"`
 	BlockNumber uint64        `json:"block_number"`
 }
+
+type HealthCheckMsg struct {
+	AvsName string         `json:"avs_name"`
+	Method  string         `json:"method"`
+	Proof   BlockWorkProof `json:"proof"`
+}

--- a/core/message/info.go
+++ b/core/message/info.go
@@ -1,0 +1,8 @@
+package message
+
+import "github.com/ethereum/go-ethereum/common/hexutil"
+
+type BlockWorkProof struct {
+	BlockHash   hexutil.Bytes `json:"block_hash"`
+	BlockNumber uint64        `json:"block_number"`
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.1
 
 require (
 	github.com/Layr-Labs/eigensdk-go v0.1.7
-	github.com/alt-research/avs-generic-aggregator v0.1.5-0.20240521140244-4b403b0f7805
+	github.com/alt-research/avs-generic-aggregator v0.1.5
 	github.com/ethereum/go-ethereum v1.14.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.1
 
 require (
 	github.com/Layr-Labs/eigensdk-go v0.1.7
-	github.com/alt-research/avs-generic-aggregator v0.1.4
+	github.com/alt-research/avs-generic-aggregator v0.1.5-0.20240521140244-4b403b0f7805
 	github.com/ethereum/go-ethereum v1.14.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=
 github.com/VictoriaMetrics/fastcache v1.12.1/go.mod h1:tX04vaqcNoQeGLD+ra5pU5sWkuxnzWhEzLwhP9w653o=
-github.com/alt-research/avs-generic-aggregator v0.1.4 h1:GzN/8ZU2aCAjtgHJ2F+wFcB0LsbU+d43qcfMYsA6gKk=
-github.com/alt-research/avs-generic-aggregator v0.1.4/go.mod h1:4Irj+o/Gz7rISGpfV+DFM6utxJAZVlt4ilzDMDljC4U=
+github.com/alt-research/avs-generic-aggregator v0.1.5-0.20240521140244-4b403b0f7805 h1:wtosyF8T8s6hRzQ8t5ONrU8fpGCfEls3q3JJJytK1rA=
+github.com/alt-research/avs-generic-aggregator v0.1.5-0.20240521140244-4b403b0f7805/go.mod h1:lE631BS7IRUJCdtT6Mb79bGIL7dwUtdSwR7XTQiU/0I=
 github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
 github.com/aws/aws-sdk-go-v2 v1.26.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/config v1.27.12 h1:vq88mBaZI4NGLXk8ierArwSILmYHDJZGJOeAc/pzEVQ=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bw
 github.com/VictoriaMetrics/fastcache v1.12.1/go.mod h1:tX04vaqcNoQeGLD+ra5pU5sWkuxnzWhEzLwhP9w653o=
 github.com/alt-research/avs-generic-aggregator v0.1.5-0.20240521140244-4b403b0f7805 h1:wtosyF8T8s6hRzQ8t5ONrU8fpGCfEls3q3JJJytK1rA=
 github.com/alt-research/avs-generic-aggregator v0.1.5-0.20240521140244-4b403b0f7805/go.mod h1:lE631BS7IRUJCdtT6Mb79bGIL7dwUtdSwR7XTQiU/0I=
+github.com/alt-research/avs-generic-aggregator v0.1.5 h1:iA6/Md+WIRAsCuPqAFuobuG/wGXvyDHJGOtloS3fOd8=
+github.com/alt-research/avs-generic-aggregator v0.1.5/go.mod h1:lE631BS7IRUJCdtT6Mb79bGIL7dwUtdSwR7XTQiU/0I=
 github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
 github.com/aws/aws-sdk-go-v2 v1.26.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/config v1.27.12 h1:vq88mBaZI4NGLXk8ierArwSILmYHDJZGJOeAc/pzEVQ=

--- a/operator/jsonrpc_server.go
+++ b/operator/jsonrpc_server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/alt-research/avs/core/alert"
+	"github.com/alt-research/avs/core/message"
 	"github.com/sourcegraph/jsonrpc2"
 )
 
@@ -99,6 +100,19 @@ func (s *RpcServer) HttpRPCHandlerRequest(w http.ResponseWriter, rpcRequest json
 
 func (s *RpcServer) HttpRPCHandlerRequestByAVS(avsName string, w http.ResponseWriter, rpcRequest jsonrpc2.Request) {
 	switch rpcRequest.Method {
+	case "health_check":
+		{
+			var msg message.BlockWorkProof
+			if err := json.Unmarshal(*rpcRequest.Params, &msg); err != nil {
+				s.logger.Error("the unmarshal", "err", err)
+				s.writeErrorJSON(w, rpcRequest.ID, http.StatusBadRequest, 3, fmt.Errorf("failed to unmarshal alert bundle params: %s", err.Error()))
+				return
+			}
+
+			s.logger.Info("health_check", "avs_name", avsName, "msg", msg)
+
+			s.writeJSON(w, rpcRequest.ID, http.StatusOK, true)
+		}
 	case "alert_blockMismatch":
 		{
 			var alert alert.AlertBlockMismatch

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -379,7 +379,8 @@ func NewOperatorFromConfig(cfg config.NodeConfig, isUseEcdsaKey bool) (*Operator
 	}
 
 	newTaskCreatedChan := make(chan alert.AlertRequest, 32)
-	rpcServer := NewRpcServer(logger, c.OperatorServerIpPortAddr, newTaskCreatedChan)
+	newWorkProofChan := make(chan message.HealthCheckMsg, 32)
+	rpcServer := NewRpcServer(logger, c.OperatorServerIpPortAddr, newTaskCreatedChan, newWorkProofChan)
 
 	operator := &Operator{
 		config:                     c,


### PR DESCRIPTION
Proxy support health check by send work proof to generic opeartor.

Now we add a new rpc api for each avs:

```bash
 curl --noproxy '*' -H "Content-Type: application/json" \
  -d '{"id":2, "jsonrpc":"2.0", "method": "health_check", "params":{"block_number": 110002, "b
lock_hash": "0x5FC5d3dd9911e4c1149d9d3abcBD16989F87570000ee00000033100000000033"}}' \
  http://127.0.0.1:8092/altLayer_mach_avs
{"id":2,"result":true,"jsonrpc":"2.0"}
```

The `health_check` will let proxy make a work proof to operator node, then it will sign by bls key then commit work proof to aggregator.