### PR TITLE
refactor: MachServiceManager and its deploy script

### DIFF
--- a/contracts/script/MachServiceManagerDeployer.s.sol
+++ b/contracts/script/MachServiceManagerDeployer.s.sol
@@ -25,7 +25,11 @@ import {OperatorStateRetriever} from "eigenlayer-middleware/OperatorStateRetriev
 import {MachServiceManager} from "../src/core/MachServiceManager.sol";
 import {IMachServiceManager} from "../src/interfaces/IMachServiceManager.sol";
 
-// forge script script/MachServiceManagerDeployer.s.sol --rpc-url $RPC_URL  --private-key $PRIVATE_KEY --broadcast -vvvv
+// forge script ./script/MachServiceManagerDeployer.s.sol \
+//     --private-key $PK \
+//     --rpc-url $URL \
+//     --etherscan-api-key $API_KEY \
+//     --broadcast -vvvv --slow --verify
 contract MachServiceManagerDeployer is Script {
     struct MachServiceContract {
         MachServiceManager machServiceManager;

--- a/contracts/script/MachServiceManagerDeployer.s.sol
+++ b/contracts/script/MachServiceManagerDeployer.s.sol
@@ -90,7 +90,7 @@ contract MachServiceManagerDeployer is Script {
         address ejector;
         address whitelister;
         address confirmer;
-        uint256 chainId;
+        uint256[] chainIds;
         uint256 numStrategies;
         uint256 numQuorum;
         uint256 maxOperatorCount;
@@ -109,6 +109,15 @@ contract MachServiceManagerDeployer is Script {
             string memory defaultPath = "./script/input/parameters.json";
             string memory deployedPath = vm.envOr(EIGENLAYER, defaultPath);
             string memory deployedEigenLayerAddresses = vm.readFile(deployedPath);
+
+            deploymentConfig.chainIds = abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".chainIds"), (uint256[]));
+            deploymentConfig.numQuorum = abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".numQuorum"), (uint256));
+            deploymentConfig.maxOperatorCount =
+                abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".maxOperatorCount"), (uint256));
+            deploymentConfig.minimumStake =
+                abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".minimumStake"), (uint96));
+            deploymentConfig.numStrategies =
+                abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".numStrategies"), (uint256));
 
             bytes memory deployedStrategyManagerData = vm.parseJson(deployedEigenLayerAddresses, ".strategyManager");
             address deployedStrategyManager = abi.decode(deployedStrategyManagerData, (address));
@@ -176,12 +185,6 @@ contract MachServiceManagerDeployer is Script {
                     abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".whitelister"), (address));
             }
         }
-
-        deploymentConfig.chainId = 10;
-        deploymentConfig.numQuorum = 1;
-        deploymentConfig.maxOperatorCount = 50;
-        deploymentConfig.minimumStake = 0;
-        deploymentConfig.numStrategies = 13;
 
         deploymentConfig.avsDirectory = address(eigenLayerContracts.avsDirectory);
         deploymentConfig.delegationManager = address(eigenLayerContracts.delegationManager);
@@ -355,7 +358,7 @@ contract MachServiceManagerDeployer is Script {
                 deploymentConfig.machAVSCommunityMultisig,
                 deploymentConfig.confirmer,
                 deploymentConfig.whitelister,
-                deploymentConfig.chainId
+                deploymentConfig.chainIds
             )
         );
         vm.stopBroadcast();

--- a/contracts/script/MachServiceManagerDeployerHolesky.s.sol
+++ b/contracts/script/MachServiceManagerDeployerHolesky.s.sol
@@ -25,8 +25,12 @@ import {OperatorStateRetriever} from "eigenlayer-middleware/OperatorStateRetriev
 import {MachServiceManager} from "../src/core/MachServiceManager.sol";
 import {IMachServiceManager} from "../src/interfaces/IMachServiceManager.sol";
 
-// forge script script/MachServiceManagerDeployer.s.sol --rpc-url $RPC_URL  --private-key $PRIVATE_KEY --broadcast -vvvv
-contract MachServiceManagerDeployer is Script {
+// forge script ./script/MachServiceManagerDeployerHolesky.s.sol \
+//     --private-key $PK \
+//     --rpc-url $URL \
+//     --etherscan-api-key $API_KEY \
+//     --broadcast -vvvv --slow --verify
+contract MachServiceManagerDeployerHolesky is Script {
     struct MachServiceContract {
         MachServiceManager machServiceManager;
         MachServiceManager machServiceManagerImplementation;

--- a/contracts/script/MachServiceManagerDeployerHolesky.s.sol
+++ b/contracts/script/MachServiceManagerDeployerHolesky.s.sol
@@ -70,7 +70,7 @@ contract MachServiceManagerDeployerHolesky is Script {
         address ejector;
         address whitelister;
         address confirmer;
-        uint256 chainId;
+        uint256[] chainIds;
         uint256 numStrategies;
         uint256 numQuorum;
         uint256 maxOperatorCount;
@@ -89,6 +89,15 @@ contract MachServiceManagerDeployerHolesky is Script {
             string memory defaultPath = "./script/input/parameters.holesky.json";
             string memory deployedPath = vm.envOr(EIGENLAYER, defaultPath);
             string memory deployedEigenLayerAddresses = vm.readFile(deployedPath);
+
+            deploymentConfig.chainIds = abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".chainIds"), (uint256[]));
+            deploymentConfig.numQuorum = abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".numQuorum"), (uint256));
+            deploymentConfig.maxOperatorCount =
+                abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".maxOperatorCount"), (uint256));
+            deploymentConfig.minimumStake =
+                abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".minimumStake"), (uint96));
+            deploymentConfig.numStrategies =
+                abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".numStrategies"), (uint256));
 
             bytes memory deployedStrategyManagerData = vm.parseJson(deployedEigenLayerAddresses, ".strategyManager");
             address deployedStrategyManager = abi.decode(deployedStrategyManagerData, (address));
@@ -129,12 +138,6 @@ contract MachServiceManagerDeployerHolesky is Script {
                     abi.decode(vm.parseJson(deployedEigenLayerAddresses, ".whitelister"), (address));
             }
         }
-
-        deploymentConfig.chainId = 10;
-        deploymentConfig.numQuorum = 1;
-        deploymentConfig.maxOperatorCount = 50;
-        deploymentConfig.minimumStake = 0;
-        deploymentConfig.numStrategies = 3;
 
         deploymentConfig.avsDirectory = address(eigenLayerContracts.avsDirectory);
         deploymentConfig.delegationManager = address(eigenLayerContracts.delegationManager);
@@ -278,9 +281,6 @@ contract MachServiceManagerDeployerHolesky is Script {
             machServiceContract.stakeRegistry
         );
 
-        uint256[] memory ids = new uint256[](1);
-        ids[0] = 10;
-
         // Third, upgrade the proxy contracts to use the correct implementation contracts and initialize them.
         machAVSProxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(machServiceContract.machServiceManager))),
@@ -292,7 +292,7 @@ contract MachServiceManagerDeployerHolesky is Script {
                 deploymentConfig.machAVSCommunityMultisig,
                 deploymentConfig.confirmer,
                 deploymentConfig.whitelister,
-                ids
+                deploymentConfig.chainIds
             )
         );
         vm.stopBroadcast();

--- a/contracts/script/MachServiceManagerImplDeployer.s.sol
+++ b/contracts/script/MachServiceManagerImplDeployer.s.sol
@@ -14,10 +14,10 @@ contract MachServiceManagerImplDeployer is Script {
         address avsDirectory = vm.envAddress("AVS_DIRECTORY");
         address registryCoordinator = vm.envAddress("REGISTRY_COORDINATOR");
         address stakeRegistry = vm.envAddress("STAKE_REGISTRY");
-        uint256 chainId = vm.envUint("CHAIN_ID");
+
         vm.startBroadcast();
         // 1. deploy new implementation contract
-        MachServiceManager machServiceManagerImplementation = new MachServiceManager(
+        new MachServiceManager(
             IAVSDirectory(avsDirectory), IRegistryCoordinator(registryCoordinator), IStakeRegistry(stakeRegistry)
         );
         vm.stopBroadcast();

--- a/contracts/script/deploy.sh
+++ b/contracts/script/deploy.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-forge script ./script/EigenLayerDeployer.s.sol \
-    --private-key $OWNER_PRIVATE \
-    --broadcast -vvvv --slow --rpc-url $RPC_URL
-
-forge script ./script/MachServiceManagerDeployer.s.sol \
-    --private-key $OWNER_PRIVATE \
-    --broadcast -vvvv --slow --rpc-url $RPC_URL

--- a/contracts/script/input/parameters.holesky.json
+++ b/contracts/script/input/parameters.holesky.json
@@ -1,4 +1,9 @@
 {
+  "chainIds": [10],
+  "numQuorum": 1,
+  "maxOperatorCount": 50,
+  "minimumStake": 0,
+  "numStrategies": 3,
   "strategyManager": "0xdfB5f6CE42aAA7830E94ECFCcAd411beF4d4D5b6",
   "avsDirectory": "0x055733000064333CaDDbC92763c58BF0192fFeBf",
   "delegationManager": "0xA44151489861Fe9e3055d95adC98FbD462B948e7",

--- a/contracts/script/input/parameters.json
+++ b/contracts/script/input/parameters.json
@@ -1,4 +1,9 @@
 {
+  "chainIds": [10],
+  "numQuorum": 1,
+  "maxOperatorCount": 50,
+  "minimumStake": 0,
+  "numStrategies": 13,
   "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
   "avsDirectory": "0x135DDa560e946695d6f155dACaFC6f1F25C1F5AF",
   "delegationManager": "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",

--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -290,7 +290,7 @@ contract MachServiceManager is
         }
 
         // check the signature
-        (QuorumStakeTotals memory quorumStakeTotals, bytes32 signatoryRecordHash) = checkSignatures(
+        (QuorumStakeTotals memory quorumStakeTotals, /* bytes32 signatoryRecordHash */ ) = checkSignatures(
             hashedHeader,
             alertHeader.quorumNumbers, // use list of uint8s instead of uint256 bitmap to not iterate 256 times
             alertHeader.referenceBlockNumber,

--- a/contracts/test/MachServiceManager.t.sol
+++ b/contracts/test/MachServiceManager.t.sol
@@ -429,10 +429,8 @@ contract MachServiceManagerTest is BLSAVSDeployer {
         serviceManager.disableAllowlist();
         vm.stopPrank();
 
-        (
-            uint32 referenceBlockNumber,
-            BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
-        ) = _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(nonRandomNumber, numNonSigners, quorumBitmap);
+        (, BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature) =
+            _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(nonRandomNumber, numNonSigners, quorumBitmap);
 
         bytes memory quorumThresholdPercentages = new bytes(1);
         quorumThresholdPercentages[0] = bytes1(uint8(67));
@@ -598,7 +596,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
     function test_QueryMessageHashes_RevertIfInvalidStartIndex() public {
         test_ConfirmAlert();
         vm.expectRevert(InvalidStartIndex.selector);
-        bytes32[] memory results = serviceManager.queryMessageHashes(1, 1, 2);
+        serviceManager.queryMessageHashes(1, 1, 2);
     }
 
     function test_RegisterOperatorToAVS_RevertIfNotInAllowlist() public {
@@ -614,11 +612,7 @@ contract MachServiceManagerTest is BLSAVSDeployer {
         vm.startPrank(proxyAdminOwner);
         serviceManager.disableAllowlist();
         vm.stopPrank();
-
-        (
-            uint32 referenceBlockNumber,
-            BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
-        ) = _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(nonRandomNumber, numNonSigners, quorumBitmap);
+        _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(nonRandomNumber, numNonSigners, quorumBitmap);
 
         vm.startPrank(address(registryCoordinator));
         serviceManager.deregisterOperatorFromAVS(0x73E2Ce949F15bE901F76b54f5a4554a6C8Dcf541);


### PR DESCRIPTION
This PR refactors MachServiceManager and its deploy script.

Note that we use the following to verify contracts:
- `--verify` 
- `--etherscan-api-key $API_KEY` 
