### PR TITLE
feat: MachServiceManagerRegistry

### DIFF
--- a/contracts/src/core/MachServiceManagerRegistry.sol
+++ b/contracts/src/core/MachServiceManagerRegistry.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+// SEE LICENSE IN https://files.altlayer.io/Alt-Research-License-1.md
+// Copyright Alt Research Ltd. 2023. All rights reserved.
+//
+// You acknowledge and agree that Alt Research Ltd. ("Alt Research") (or Alt
+// Research's licensors) own all legal rights, titles and interests in and to the
+// work, software, application, source code, documentation and any other documents
+
+pragma solidity =0.8.12;
+
+import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+import {IMachServiceManager} from "../interfaces/IMachServiceManager.sol";
+
+import {ZeroAddress, AlreadyAdded} from "../error/Errors.sol";
+
+contract MachServiceManagerRegistry is OwnableUpgradeable {
+    // rollup chain ID => service manager
+    mapping(uint256 => IMachServiceManager) public serviceManagers;
+
+    event ServiceManagerRegistered(uint256 rollupChainId_, IMachServiceManager serviceManager_, address sender);
+
+    function initialize() external initializer {
+        __Ownable_init();
+    }
+
+    function registerServiceManager(uint256 rollupChainId_, IMachServiceManager serviceManager_) external onlyOwner {
+        if (address(serviceManager_) == address(0)) {
+            revert ZeroAddress();
+        }
+        if (serviceManagers[rollupChainId_] == serviceManager_) {
+            revert AlreadyAdded();
+        }
+        serviceManagers[rollupChainId_] = serviceManager_;
+        emit ServiceManagerRegistered(rollupChainId_, serviceManager_, _msgSender());
+    }
+
+    function hasActiveAlerts(uint256 rollupChainId_) external view returns (bool) {
+        return serviceManagers[rollupChainId_].totalAlerts(rollupChainId_) > 0;
+    }
+}

--- a/contracts/src/core/MachServiceManagerRegistry.sol
+++ b/contracts/src/core/MachServiceManagerRegistry.sol
@@ -10,19 +10,29 @@ pragma solidity =0.8.12;
 
 import {OwnableUpgradeable} from "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import {IMachServiceManager} from "../interfaces/IMachServiceManager.sol";
-
 import {ZeroAddress, AlreadyAdded} from "../error/Errors.sol";
 
+/// @title MachServiceManagerRegistry
+/// @notice This contract allows the owner to register service managers for specific rollup chain IDs and check if they have active alerts.
 contract MachServiceManagerRegistry is OwnableUpgradeable {
-    // rollup chain ID => service manager
+    // Mapping of rollup chain ID to service manager
     mapping(uint256 => IMachServiceManager) public serviceManagers;
 
+    /// @notice Emitted when a service manager is registered
+    /// @param rollupChainId_ The rollup chain ID
+    /// @param serviceManager_ The registered service manager
+    /// @param sender The address that registered the service manager
     event ServiceManagerRegistered(uint256 rollupChainId_, IMachServiceManager serviceManager_, address sender);
 
+    /// @notice Initializes the contract and sets the deployer as the owner
     function initialize() external initializer {
         __Ownable_init();
     }
 
+    /// @notice Registers a service manager for a specific rollup chain ID
+    /// @param rollupChainId_ The rollup chain ID
+    /// @param serviceManager_ The service manager to be registered
+    /// @dev Reverts if the service manager address is zero or already registered
     function registerServiceManager(uint256 rollupChainId_, IMachServiceManager serviceManager_) external onlyOwner {
         if (address(serviceManager_) == address(0)) {
             revert ZeroAddress();
@@ -34,6 +44,9 @@ contract MachServiceManagerRegistry is OwnableUpgradeable {
         emit ServiceManagerRegistered(rollupChainId_, serviceManager_, _msgSender());
     }
 
+    /// @notice Checks if a service manager has active alerts
+    /// @param rollupChainId_ The rollup chain ID
+    /// @return True if there are active alerts, false otherwise
     function hasActiveAlerts(uint256 rollupChainId_) external view returns (bool) {
         return serviceManagers[rollupChainId_].totalAlerts(rollupChainId_) > 0;
     }

--- a/contracts/test/MachServiceManagerRegistry.t.sol
+++ b/contracts/test/MachServiceManagerRegistry.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.12;
+
+import "forge-std/Test.sol";
+import "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+import "../src/interfaces/IMachServiceManager.sol";
+import "../src/core/MachServiceManagerRegistry.sol";
+import "../src/error/Errors.sol";
+
+contract MachServiceManagerRegistryTest is Test {
+    MachServiceManagerRegistry registry;
+    IMachServiceManager mockServiceManager;
+
+    event ServiceManagerRegistered(uint256 rollupChainId_, IMachServiceManager serviceManager_, address sender);
+
+    function setUp() public {
+        // Deploy the registry
+        registry = new MachServiceManagerRegistry();
+        registry.initialize();
+
+        // Mocking the IMachServiceManager interface
+        mockServiceManager = IMachServiceManager(address(1));
+
+        // Ensure registry is owned by this test contract for testing purposes
+        registry.transferOwnership(address(this));
+    }
+
+    function test_RegisterServiceManager() public {
+        uint256 rollupChainId = 1;
+
+        vm.expectEmit(true, true, true, true);
+        emit ServiceManagerRegistered(rollupChainId, mockServiceManager, address(this));
+
+        registry.registerServiceManager(rollupChainId, mockServiceManager);
+
+        assertEq(
+            address(registry.serviceManagers(rollupChainId)), address(mockServiceManager), "Service manager mismatch"
+        );
+    }
+
+    function test_RegisterServiceManager_RevertIfZeroAddress() public {
+        uint256 rollupChainId = 1;
+
+        vm.expectRevert(ZeroAddress.selector);
+        registry.registerServiceManager(rollupChainId, IMachServiceManager(address(0)));
+    }
+
+    function test_RegisterServiceManager_RevertIfAlreadyAdded() public {
+        uint256 rollupChainId = 1;
+
+        registry.registerServiceManager(rollupChainId, mockServiceManager);
+
+        vm.expectRevert(AlreadyAdded.selector);
+        registry.registerServiceManager(rollupChainId, mockServiceManager);
+    }
+
+    function test_RegisterServiceManager_RevertIfNotOwner() public {
+        uint256 rollupChainId = 1;
+
+        // Transfer ownership to another address for this test
+        registry.transferOwnership(address(0xdead));
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.registerServiceManager(rollupChainId, mockServiceManager);
+    }
+
+    function test_HasActiveAlerts() public {
+        uint256 rollupChainId = 1;
+
+        // Mocking the behavior of totalAlerts to return a non-zero value
+        vm.mockCall(
+            address(mockServiceManager),
+            abi.encodeWithSelector(IMachServiceManager.totalAlerts.selector, rollupChainId),
+            abi.encode(1)
+        );
+
+        registry.registerServiceManager(rollupChainId, mockServiceManager);
+
+        bool hasAlerts = registry.hasActiveAlerts(rollupChainId);
+
+        assertTrue(hasAlerts, "Expected to have active alerts");
+    }
+
+    function test_HasActiveAlerts_NoAlerts() public {
+        uint256 rollupChainId = 1;
+
+        // Mocking the behavior of totalAlerts to return zero
+        vm.mockCall(
+            address(mockServiceManager),
+            abi.encodeWithSelector(IMachServiceManager.totalAlerts.selector, rollupChainId),
+            abi.encode(0)
+        );
+
+        registry.registerServiceManager(rollupChainId, mockServiceManager);
+
+        bool hasAlerts = registry.hasActiveAlerts(rollupChainId);
+
+        assertFalse(hasAlerts, "Expected to have no active alerts");
+    }
+}


### PR DESCRIPTION
This PR introduces the `MachServiceManagerRegistry` contract, allowing the owner to register service manager contracts for specific rollup chain IDs and check for active alerts.



