### PR TITLE
feat: Opt-in cmd support add quorum args

### DIFF
--- a/legacy/cli/actions/register_operator_with_avs.go
+++ b/legacy/cli/actions/register_operator_with_avs.go
@@ -52,7 +52,7 @@ func RegisterOperatorWithAvs(ctx *cli.Context) error {
 	quorumNumbers := []byte{0}
 
 	quorumNumbersEnvStr, ok := os.LookupEnv("REG_QUORUM_NUMBERS")
-	if !ok && quorumNumbersEnvStr != "" {
+	if ok && quorumNumbersEnvStr != "" {
 		log.Printf("use REG_QUORUM_NUMBERS %v", quorumNumbersEnvStr)
 		quorumNumbers, err = parseQuorumNumbers(quorumNumbersEnvStr)
 		if err != nil {

--- a/legacy/cli/actions/register_operator_with_avs.go
+++ b/legacy/cli/actions/register_operator_with_avs.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"strconv"
+	"strings"
 
 	sdkecdsa "github.com/Layr-Labs/eigensdk-go/crypto/ecdsa"
 	sdkutils "github.com/Layr-Labs/eigensdk-go/utils"
 	"github.com/alt-research/avs/legacy/core/config"
 	"github.com/alt-research/avs/legacy/operator"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -46,10 +49,50 @@ func RegisterOperatorWithAvs(ctx *cli.Context) error {
 		return err
 	}
 
-	err = operator.RegisterOperatorWithAvs(operatorEcdsaPrivKey)
+	quorumNumbers := []byte{0}
+
+	quorumNumbersEnvStr, ok := os.LookupEnv("REG_QUORUM_NUMBERS")
+	if !ok && quorumNumbersEnvStr != "" {
+		log.Printf("use REG_QUORUM_NUMBERS %v", quorumNumbersEnvStr)
+		quorumNumbers, err = parseQuorumNumbers(quorumNumbersEnvStr)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse REG_QUORUM_NUMBERS into quorumNumbers")
+		}
+	}
+
+	quorumNumbersStr := ctx.String("quorum-numbers")
+	if quorumNumbersStr != "" {
+		log.Printf("use --quorum-numbers %v", quorumNumbersEnvStr)
+		quorumNumbers, err = parseQuorumNumbers(quorumNumbersEnvStr)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse --quorum-numbers into quorumNumbers")
+		}
+	}
+
+	err = operator.RegisterOperatorWithAvs(operatorEcdsaPrivKey, quorumNumbers)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func parseQuorumNumbers(str string) ([]byte, error) {
+	strArray := strings.Split(str, ",")
+
+	res := make([]byte, 0, len(strArray))
+	for i, s := range strArray {
+		si, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to atoi %s in pos %v", s, i)
+		}
+
+		if si < 0 || si >= 192 {
+			return nil, errors.Errorf("failed by %v not in [0, 192)", si)
+		}
+
+		res = append(res, byte(si))
+	}
+
+	return res, nil
 }

--- a/legacy/cli/main.go
+++ b/legacy/cli/main.go
@@ -43,6 +43,12 @@ func main() {
 			Aliases: []string{"r"},
 			Usage:   "registers bls keys with pubkey-compendium, opts into slashing by avs service-manager, and registers operators with avs registry",
 			Action:  actions.RegisterOperatorWithAvs,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "quorum-numbers",
+					Usage: "The quorum numbers, if not set, will be 0",
+				},
+			},
 		},
 		{
 			Name:    "deregister-operator-with-avs",

--- a/legacy/operator/registration.go
+++ b/legacy/operator/registration.go
@@ -50,9 +50,9 @@ func (o *Operator) DepositIntoStrategy(strategyAddr common.Address, amount *big.
 // Registration specific functions
 func (o *Operator) RegisterOperatorWithAvs(
 	operatorEcdsaKeyPair *ecdsa.PrivateKey,
+	quorumNumbers []byte,
 ) error {
 	// hardcode these things for now
-	quorumNumbers := []byte{0}
 	socket := o.config.OperatorSocket
 
 	// Generate salt and expiry


### PR DESCRIPTION
Add a env var to select the quorums for opt-in:

```bash
# means the operator will opt-in by quorum 0 and 2, need restack enough token
REG_QUORUM_NUMBERS=0,2
```

For a operator had opt-in, should opt-out first then use opt-in.