### PR TITLE
feat: enumerable allowlist

### DIFF
--- a/contracts/script/CreateAVSRewardsSubmission.s.sol
+++ b/contracts/script/CreateAVSRewardsSubmission.s.sol
@@ -66,7 +66,7 @@ contract CreateAVSRewardsSubmission is Script {
         );
 
         IRewardsCoordinator.RewardsSubmission[] memory rewardsSubmissions =
-            new IRewardsCoordinator.RewardsSubmission[](1) ;
+            new IRewardsCoordinator.RewardsSubmission[](1);
 
         AltLayerInu rewardToken = new AltLayerInu();
         uint256 amount = 1000000 ether;

--- a/contracts/src/core/MachServiceManagerStorage.sol
+++ b/contracts/src/core/MachServiceManagerStorage.sol
@@ -21,13 +21,10 @@ abstract contract MachServiceManagerStorage {
     // Slot 1
     mapping(uint256 => EnumerableSet.Bytes32Set) internal _messageHashes;
 
-    // Slot 2, 3
-    /// @notice Ethereum addresses of currently register operators
-    EnumerableSet.AddressSet internal _operators;
-
-    // Slot 4
-    /// @notice Set of operators that are allowed to register
-    mapping(address => bool) public allowlist;
+    // Slot 2, 3, 4
+    bytes32 private __DEPRECATED_SLOT2;
+    bytes32 private __DEPRECATED_SLOT3;
+    bytes32 private __DEPRECATED_SLOT4;
 
     // Slot 5
     /// @notice address that is permissioned to confirm alerts
@@ -50,7 +47,10 @@ abstract contract MachServiceManagerStorage {
     /// @notice Role for whitelisting operators
     address public whitelister;
 
+    /// @notice Set of operators that are allowed to register
+    EnumerableSet.AddressSet internal _allowlist;
+
     // storage gap for upgradeability
     // slither-disable-next-line shadowing-state
-    uint256[44] private __GAP;
+    uint256[42] private __GAP;
 }

--- a/contracts/src/interfaces/IMachServiceManager.sol
+++ b/contracts/src/interfaces/IMachServiceManager.sol
@@ -37,17 +37,7 @@ interface IMachServiceManager is IServiceManager {
         uint256 rollupChainID;
     }
 
-    /**
-     * @notice Emitted when an operator is added to the MachServiceManagerAVS.
-     * @param operator The address of the operator
-     */
-    event OperatorAdded(address indexed operator);
-
-    /**
-     * @notice Emitted when an operator is removed from the MachServiceManagerAVS.
-     * @param operator The address of the operator
-     */
-    event OperatorRemoved(address indexed operator);
+    event AllowlistUpdated(address[] operators, bool[] status);
 
     /**
      * @notice Emitted when the alert confirmer is changed.
@@ -109,18 +99,6 @@ interface IMachServiceManager is IServiceManager {
      * @param messageHash The sender address
      */
     event AlertRemoved(bytes32 messageHash, address sender);
-
-    /**
-     * @notice Add  operators to the allowlist.
-     * @param operator The operators to add
-     */
-    function allowOperators(address[] calldata operator) external;
-
-    /**
-     * @notice Remove operators from the allowlist.
-     * @param operator The operators to remove
-     */
-    function disallowOperators(address[] calldata operator) external;
 
     /**
      * @notice Enable the allowlist.


### PR DESCRIPTION
This pull request refactors the allowlist management system in the `MachServiceManager` contract to simplify operator management and improve functionality. The changes consolidate the addition and removal of operators into a single function, replace mappings with `EnumerableSet` for better efficiency, and update related tests and interfaces accordingly.

### Allowlist Management Refactor:
* Replaced `allowOperators` and `disallowOperators` functions with a unified `setAllowlist` function, which accepts arrays of operators and their statuses, ensuring consistent updates to the allowlist. (`contracts/src/core/MachServiceManager.sol`, [contracts/src/core/MachServiceManager.solL130-R146](diffhunk://#diff-32e91011ec699822544c63b0203444e8f366098c5b6027b41f7fac1404779762L130-R146))
* Introduced helper functions `isOperatorAllowed`, `getAllowlistSize`, and `getAllowlistAtIndex` for querying the allowlist. (`contracts/src/core/MachServiceManager.sol`, [contracts/src/core/MachServiceManager.solR367-R378](diffhunk://#diff-32e91011ec699822544c63b0203444e8f366098c5b6027b41f7fac1404779762R367-R378))
* Updated the allowlist implementation to use `EnumerableSet.AddressSet` instead of a mapping for better efficiency and added a new `AllowlistUpdated` event. (`contracts/src/core/MachServiceManagerStorage.sol`, [[1]](diffhunk://#diff-cc0fa7cacdfc07cbe5129374fe0a285f2ba1e0fc5932ff37795e282fa55f2828L24-R27) [[2]](diffhunk://#diff-cc0fa7cacdfc07cbe5129374fe0a285f2ba1e0fc5932ff37795e282fa55f2828R50-R55); `contracts/src/interfaces/IMachServiceManager.sol`, [[3]](diffhunk://#diff-bedef4782263fb72e508428d280f8d4ab9a5cbb87e6e482bc4b927cf84e6a5efL40-R40)

### Removal of Deprecated Code:
* Removed the `_operators` set and the `OperatorAdded` and `OperatorRemoved` events, as they are no longer necessary with the new allowlist system. (`contracts/src/core/MachServiceManagerStorage.sol`, [[1]](diffhunk://#diff-cc0fa7cacdfc07cbe5129374fe0a285f2ba1e0fc5932ff37795e282fa55f2828L24-R27); `contracts/src/interfaces/IMachServiceManager.sol`, [[2]](diffhunk://#diff-bedef4782263fb72e508428d280f8d4ab9a5cbb87e6e482bc4b927cf84e6a5efL40-R40)
* Deprecated the old allowlist mapping and adjusted the storage layout to maintain upgradeability. (`contracts/src/core/MachServiceManagerStorage.sol`, [contracts/src/core/MachServiceManagerStorage.solL24-R27](diffhunk://#diff-cc0fa7cacdfc07cbe5129374fe0a285f2ba1e0fc5932ff37795e282fa55f2828L24-R27))

### Test Updates:
* Refactored tests to align with the new `setAllowlist` function, consolidating multiple test cases into a single, streamlined approach. (`contracts/test/MachServiceManager.t.sol`, [contracts/test/MachServiceManager.t.solL80-R119](diffhunk://#diff-12c69982c0e5b06cb7075f68af59d9633e4b4b5f4de274ef47ea556fcc7a34eeL80-R119))
* Updated emitted event expectations to reflect the new `AllowlistUpdated` event. (`contracts/test/MachServiceManager.t.sol`, [contracts/test/MachServiceManager.t.solL12-R13](diffhunk://#diff-12c69982c0e5b06cb7075f68af59d9633e4b4b5f4de274ef47ea556fcc7a34eeL12-R13))