### PR TITLE
feat: add query operator status rpc api for proxy

### DIFF
--- a/generic-operator-proxy/proxy.go
+++ b/generic-operator-proxy/proxy.go
@@ -133,6 +133,31 @@ func (s *ProxyHashRpcServer) handerConfigReq(
 	operator.WriteJSON(s.logger, w, rpcRequest.ID, json.RawMessage(cfg))
 }
 
+func (s *ProxyHashRpcServer) handerOperatorStatusReq(
+	ctx context.Context,
+	w http.ResponseWriter,
+	rpcRequest jsonrpc2.Request) {
+
+	resp, err := s.OperatorStatus(ctx)
+
+	if err != nil {
+		operator.WriteErrorJSON(
+			s.logger, w, rpcRequest.ID, http.StatusBadRequest, 3,
+			err)
+		return
+	}
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		operator.WriteErrorJSON(
+			s.logger, w, rpcRequest.ID, http.StatusBadRequest, 3,
+			err)
+		return
+	}
+
+	operator.WriteJSON(s.logger, w, rpcRequest.ID, json.RawMessage(raw))
+}
+
 func (s *ProxyHashRpcServer) HttpRPCHandler(w http.ResponseWriter, r *http.Request) {
 	rpcRequest := jsonrpc2.Request{}
 	err := json.NewDecoder(r.Body).Decode(&rpcRequest)
@@ -151,6 +176,8 @@ func (s *ProxyHashRpcServer) HttpRPCHandler(w http.ResponseWriter, r *http.Reque
 
 	if rpcRequest.Method == "operator_getConfig" {
 		s.handerConfigReq(w, rpcRequest)
+	} else if rpcRequest.Method == "operator_operatorStatus" {
+		s.handerOperatorStatusReq(r.Context(), w, rpcRequest)
 	} else {
 		s.rpcServer.HttpRPCHandlerRequest(w, rpcRequest)
 	}

--- a/generic-operator-proxy/proxy.go
+++ b/generic-operator-proxy/proxy.go
@@ -399,7 +399,7 @@ func (s *ProxyHashRpcServer) OperatorStatus(ctx context.Context) (OperatorStatus
 	}
 
 	err = client.CallContext(
-		ctx, &res, "operator_operatorStatus")
+		ctx, &res, "operator_operatorStatus", []interface{}{})
 	if err != nil {
 		return res, errors.Wrapf(err, "call OperatorStatus failed")
 	}


### PR DESCRIPTION
```
 curl --noproxy '*' -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "operator_operatorStatus", "params":[]}'  http://127.0.0.1:8902
{"id":"1","result":{"node_name":"generic_operator","version":"rev-a12784a","avs":[{"avs_name":"op_sepolia","avs_contract_address":"0xAE9a4497dee2540DaF489BeddB0706128a99ec63","operator_id":"0x5a76fe9014f9cd296a69ac589c2bbd2c6a354c5e4c0c79ee35c5b8202b8523a2","operator_address":"0xAD6B95793DD4D2b8e184FB4666D1cfb14871A035"},{"avs_name":"arbitrum_one_testnet3","avs_contract_address":"0xAE9a4497dee2540DaF489BeddB0706128a99ec63","operator_id":"0x5a76fe9014f9cd296a69ac589c2bbd2c6a354c5e4c0c79ee35c5b8202b8523a2","operator_address":"0xAD6B95793DD4D2b8e184FB4666D1cfb14871A035"}]},"jsonrpc":"2.0"}
```