### PR TITLE
Fix grammatical errors in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sequenceDiagram
     MV ->> L2: Fetch next blocks
     else the block is invalid
     MV ->> MO: Commit alert to operator
-    MV ->> MC: Commit an Earlier Alert
+    MV ->> MC: Commit an earlier Alert
     MO ->> MO: Sig the alert
     MO ->> MA: Commit alert bls sig
     MA ->> MC: If collected, commit Avs confirmed Alert

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sequenceDiagram
     MV ->> L2: Fetch next blocks
     else the block is invalid
     MV ->> MO: Commit alert to operator
-    MV ->> MC: Commit a Earlier Alert
+    MV ->> MC: Commit an Earlier Alert
     MO ->> MO: Sig the alert
     MO ->> MA: Commit alert bls sig
     MA ->> MC: If collected, commit Avs confirmed Alert
@@ -176,7 +176,7 @@ docker compose build
 docker compose up
 ```
 
-it will boot anvil as layer1, a aggregator and a operator for test.
+it will boot anvil as layer1, an aggregator and a operator for test.
 
 ## Build and Run
 

--- a/contracts/src/core/MachOptimismZkServiceManager.sol
+++ b/contracts/src/core/MachOptimismZkServiceManager.sol
@@ -449,7 +449,7 @@ contract MachOptimismZkServiceManager is
             })
         );
 
-        // For the proved output, if there are exist a early block alert
+        // For the proved output, if there are exist an early block alert
         // we will make it not proved! so we just set to `length`
         provedIndex = l2OutputAlerts.length;
     }

--- a/contracts/src/core/MachOptimismZkServiceManagerStorage.sol
+++ b/contracts/src/core/MachOptimismZkServiceManagerStorage.sol
@@ -22,7 +22,7 @@ contract MachOptimismZkServiceManagerStorage {
     bytes32 public imageId;
 
     // Alerts for blocks, the tail is for earliest block.
-    // For the proved output, if there are exist a early block alert
+    // For the proved output, if there are exist an early block alert
     // we will make it not proved!
     IMachOptimism.L2OutputAlert[] internal l2OutputAlerts;
     // The next index for no proved alert,

--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -406,7 +406,7 @@ contract MachServiceManager is
     }
 
     /**
-     * @dev Converts a alert header to a reduced alert header
+     * @dev Converts an alert header to a reduced alert header
      * @param alertHeader the alert header to convert
      */
     function _convertAlertHeaderToReducedAlertHeader(AlertHeader calldata alertHeader)

--- a/contracts/src/interfaces/IMachServiceManager.sol
+++ b/contracts/src/interfaces/IMachServiceManager.sol
@@ -87,14 +87,14 @@ interface IMachServiceManager is IServiceManager {
     event RollupChainIDUpdated(uint256 rollupChainId, bool status);
 
     /**
-     * @notice Emitted when a Alert is confirmed.
+     * @notice Emitted when an Alert is confirmed.
      * @param alertHeaderHash The hash of the alert header
      * @param messageHash The message hash
      */
     event AlertConfirmed(bytes32 indexed alertHeaderHash, bytes32 messageHash);
 
     /**
-     * @notice Emitted when a Alert is removed.
+     * @notice Emitted when an Alert is removed.
      * @param messageHash The message hash
      * @param messageHash The sender address
      */

--- a/legacy/aggregator/rpc/grpc.go
+++ b/legacy/aggregator/rpc/grpc.go
@@ -79,7 +79,7 @@ func (s *GRpcHandler) InitOperator(ctx context.Context, req *aggregator.InitOper
 	return resp.ToPbType(), nil
 }
 
-// Create a alert task
+// Create an alert task
 func (s *GRpcHandler) CreateTask(ctx context.Context, req *aggregator.CreateTaskRequest) (*aggregator.CreateTaskResponse, error) {
 	msg, err := message.NewCreateTaskRequest(req)
 	if err != nil {

--- a/legacy/api/grpc/aggregator/aggregator_grpc.pb.go
+++ b/legacy/api/grpc/aggregator/aggregator_grpc.pb.go
@@ -24,7 +24,7 @@ const _ = grpc.SupportPackageIsVersion7
 type AggregatorClient interface {
 	// Send Init operator to aggregator from operator, will check if the config is matching
 	InitOperator(ctx context.Context, in *InitOperatorRequest, opts ...grpc.CallOption) (*InitOperatorResponse, error)
-	// Create a alert task
+	// Create an alert task
 	CreateTask(ctx context.Context, in *CreateTaskRequest, opts ...grpc.CallOption) (*CreateTaskResponse, error)
 	// Send signed task for alert
 	ProcessSignedTaskResponse(ctx context.Context, in *SignedTaskRespRequest, opts ...grpc.CallOption) (*SignedTaskRespResponse, error)
@@ -71,7 +71,7 @@ func (c *aggregatorClient) ProcessSignedTaskResponse(ctx context.Context, in *Si
 type AggregatorServer interface {
 	// Send Init operator to aggregator from operator, will check if the config is matching
 	InitOperator(context.Context, *InitOperatorRequest) (*InitOperatorResponse, error)
-	// Create a alert task
+	// Create an alert task
 	CreateTask(context.Context, *CreateTaskRequest) (*CreateTaskResponse, error)
 	// Send signed task for alert
 	ProcessSignedTaskResponse(context.Context, *SignedTaskRespRequest) (*SignedTaskRespResponse, error)


### PR DESCRIPTION
This PR addresses multiple grammatical errors in comments and documentation across various files in the repository. The changes ensure proper English grammar usage and improve readability.

#### **Files Changed:**

1. **`README.md`**  
   - Corrected "a Earlier Alert" to "an Earlier Alert."
   - Corrected "a aggregator and a operator" to "an aggregator and a operator."

2. **`MachOptimismZkServiceManager.sol`**  
   - Corrected "a early block alert" to "an early block alert."

3. **`MachOptimismZkServiceManagerStorage.sol`**  
   - Corrected "a early block alert" to "an early block alert."

4. **`MachServiceManager.sol`**  
   - Corrected "a alert header" to "an alert header."

5. **`IMachServiceManager.sol`**  
   - Corrected "a Alert" to "an Alert" in multiple comments.

6. **`grpc.go`**  
   - Corrected "a alert task" to "an alert task."

7. **`aggregator_grpc.pb.go`**  
   - Corrected similar grammatical inconsistencies in the generated file.