### PR TITLE
fix: remove sender validation in alert confirmation

### DIFF
--- a/contracts/src/core/MachServiceManager.sol
+++ b/contracts/src/core/MachServiceManager.sol
@@ -268,11 +268,6 @@ contract MachServiceManager is
         AlertHeader calldata alertHeader,
         IBLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
     ) external whenNotPaused onlyAlertConfirmer onlyValidRollupChainID(alertHeader.rollupChainID) {
-        // make sure the information needed to derive the non-signers and batch is in calldata to avoid emitting events
-        if (tx.origin != msg.sender) {
-            revert InvalidSender();
-        }
-
         // check is it is the resolved alert before
         if (_resolvedMessageHashes[alertHeader.rollupChainID].contains(alertHeader.messageHash)) {
             revert ResolvedAlert();

--- a/contracts/test/MachServiceManager.t.sol
+++ b/contracts/test/MachServiceManager.t.sol
@@ -291,36 +291,6 @@ contract MachServiceManagerTest is BLSAVSDeployer {
         serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
     }
 
-    function test_ConfirmAlert_RevertIfInvalidSender() public {
-        vm.startPrank(proxyAdminOwner, proxyAdminOwner);
-        serviceManager.disableAllowlist();
-        (
-            uint32 referenceBlockNumber,
-            BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature
-        ) = _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(nonRandomNumber, numNonSigners, quorumBitmap);
-        vm.stopPrank();
-
-        bytes memory quorumThresholdPercentages = new bytes(1);
-        quorumThresholdPercentages[0] = bytes1(uint8(67));
-
-        IMachServiceManager.AlertHeader memory alertHeader = IMachServiceManager.AlertHeader({
-            messageHash: "foo",
-            quorumNumbers: quorumNumbers,
-            quorumThresholdPercentages: quorumThresholdPercentages,
-            referenceBlockNumber: referenceBlockNumber,
-            rollupChainID: 1
-        });
-
-        vm.startPrank(proxyAdminOwner, proxyAdminOwner);
-        serviceManager.setConfirmer(address(this));
-        vm.stopPrank();
-
-        vm.startPrank(address(this));
-        vm.expectRevert(InvalidSender.selector);
-        serviceManager.confirmAlert(alertHeader, nonSignerStakesAndSignature);
-        vm.stopPrank();
-    }
-
     function test_ConfirmAlert_RevertIfAlreadyAdded() public {
         vm.startPrank(proxyAdminOwner, proxyAdminOwner);
         serviceManager.disableAllowlist();


### PR DESCRIPTION
This pull request includes a change to the `MachServiceManager` contract in the `contracts/src/core/MachServiceManager.sol` file. The most important change is the removal of a validation check that ensured the transaction origin was the same as the message sender.

Codebase simplification:

* [`contracts/src/core/MachServiceManager.sol`](diffhunk://#diff-32e91011ec699822544c63b0203444e8f366098c5b6027b41f7fac1404779762L271-L275): Removed the validation check that compared `tx.origin` with `msg.sender` and the associated `InvalidSender` error.


Context:
- https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md
- https://www.alchemy.com/blog/eip-7702-ethereum-pectra-hardfork